### PR TITLE
New CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+---
+image: alpine:latest
+
+stages:
+  - verify
+  - build
+  - test
+  - stage
+  - release
+
+include:

--- a/.gitlab-templates/docker-ci.yml
+++ b/.gitlab-templates/docker-ci.yml
@@ -1,0 +1,11 @@
+---
+docker:
+  stage: docker
+  image: docker
+  services:
+  - docker:dind
+  script:
+    - docker build -t ${CI_PROJECT_NAME} .
+    - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+    - docker tag ${CI_PROJECT_NAME} ${DOCKER_ACCOUNT}/${CI_PROJECT_NAME}
+    - docker push ${DOCKER_ACCOUNT}/${CI_PROJECT_NAME}

--- a/.gitlab-templates/java-ci.yml
+++ b/.gitlab-templates/java-ci.yml
@@ -1,0 +1,31 @@
+---
+variables:
+  MAVEN_IMAGE_TAG: 3-jdk-8
+  MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+  MAVEN_OPTS: "-Dmaven.repo.local=.m2/repository"
+
+cache:
+  paths:
+    - .m2/repository/
+
+
+
+build:
+  stage: build
+  image: maven:$MAVEN_IMAGE_TAG
+  script:
+    - mvn $MAVEN_CLI_OPTS clean verify
+
+test:
+  stage: test
+  image: maven:$MAVEN_IMAGE_TAG
+  script:
+    - mvn $MAVEN_CLI_OPTS clean test
+
+publish:
+  stage: release
+  image: maven:$MAVEN_IMAGE_TAG
+  script:
+    - mvn $MAVEN_CLI_OPTS clean deploy
+  only:
+    - master

--- a/.gitlab-templates/python-ci.yml
+++ b/.gitlab-templates/python-ci.yml
@@ -1,0 +1,36 @@
+---
+tox:
+  stage: verify
+  image: python:3
+  before_script:
+    - pip install tox
+  script:
+    - tox
+
+build:
+  stage: build
+  image: python:3
+  before_script:
+    - pip install setuptools wheel
+  script:
+    - python setup.py sdist bdist_wheel
+  artifacts:
+    paths:
+    - dist
+    - build
+
+publish:
+  stage: publish
+  image: python:3
+  dependencies: 
+    - build
+  variables:
+      TWINE_URL: $PYPI_URL
+      TWINE_USERNAME: $PYPI_USERNAME
+      TWINE_PASSWORD: $PYPI_PASSWORD
+  before_script:
+    - pip install twine
+  script:
+    - twine upload --repository-url $PYPI_URL dist/*
+  only:
+    - master

--- a/.gitlab-templates/rtd-ci.yml
+++ b/.gitlab-templates/rtd-ci.yml
@@ -1,0 +1,12 @@
+---
+build:
+  stage: docs
+  image: python:3
+  before_script:
+    - pip install sphinx sphinx-rtd-theme sphinxcontrib-httpdomain recommonmark
+  script:
+    - sphinx-build -b html -W -n ./docs ./docs/_build/html
+  artifacts:
+    name: "docs"
+    paths:
+      - ./docs/_build/html


### PR DESCRIPTION
Add new CI please!
# CI/CD on gitlab-ci

This pull requests adds The Linux Foundation docker
toolchain for CI/CD workflows on gitlab-ci.

## Toolchain

The CI/CD workflows for this repository are triggered by the following:

* Pull Requests: Pull requests against master will verify the project
  container can be built. The container won't be pushed anywhere.
* Merge: Merges to the repository build the docker container and tag it
  with ':latest', and 
  push it to dockerhub. 
* Release: On tags, the container is built, tagged with both the
  specified tag and ':latest' and pushed to dockerhub.


## Docker Environment Variables

The following variables are available to workflows:
- `$DOCKER_IMAGE`
  Name of the docker image to create
- `$DOCKER_BUILDCONTEXT`
  Path to the build context for the docker image
- `$DOCKER_FILEPATH`
  Path to the Dockerfile being built
- `$DOCKER_REPOSITORY`
  Name of the docker registry repository where the image will be
  distributed
## Validating CI Locally

gitlab-ci jobs can be verified with:

gitlab-runner exec docker verify



## Updating this Pull Request

If these workflows don't match the needs for your project feel free to
[modify](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally)
them to meet your needs.

Signed-off-by: ITX CI \<itx@linuxfoundation.org\>
on-behalf-of: @linuxfoundation-it \<itx@linuxfoundation.org\>